### PR TITLE
Add department support to users and apps

### DIFF
--- a/api/commands.py
+++ b/api/commands.py
@@ -655,8 +655,9 @@ def create_tenant(email: str, language: Optional[str] = None, name: Optional[str
         password=new_password,
         language=language,
         create_workspace_required=False,
+        department=None,
     )
-    TenantService.create_owner_tenant_if_not_exist(account, name)
+    TenantService.create_owner_tenant_if_not_exist(account, name, department=None)
 
     click.echo(
         click.style(

--- a/api/controllers/console/app/app.py
+++ b/api/controllers/console/app/app.py
@@ -69,7 +69,12 @@ class AppListApi(Resource):
 
         # get app list
         app_service = AppService()
-        app_pagination = app_service.get_paginate_apps(current_user.id, current_user.current_tenant_id, args)
+        app_pagination = app_service.get_paginate_apps(
+            current_user.id,
+            current_user.current_tenant_id,
+            args,
+            department=current_user.current_department,
+        )
         if not app_pagination:
             return {"data": [], "total": 0, "page": 1, "limit": 20, "has_more": False}
 

--- a/api/controllers/console/auth/oauth.py
+++ b/api/controllers/console/auth/oauth.py
@@ -114,7 +114,7 @@ class OAuthCallback(Resource):
             db.session.commit()
 
         try:
-            TenantService.create_owner_tenant_if_not_exist(account)
+            TenantService.create_owner_tenant_if_not_exist(account, department=None)
         except Unauthorized:
             return redirect(f"{dify_config.CONSOLE_WEB_URL}/signin?message=Workspace not found.")
         except WorkSpaceNotAllowedCreateError:
@@ -163,7 +163,12 @@ def _generate_account(provider: str, user_info: OAuthUserInfo):
             raise AccountNotFoundError()
         account_name = user_info.name or "Dify"
         account = RegisterService.register(
-            email=user_info.email, name=account_name, password=None, open_id=user_info.id, provider=provider
+            email=user_info.email,
+            name=account_name,
+            password=None,
+            open_id=user_info.id,
+            provider=provider,
+            department=None,
         )
 
         # Set interface language

--- a/api/controllers/console/setup.py
+++ b/api/controllers/console/setup.py
@@ -40,11 +40,16 @@ class SetupApi(Resource):
         parser.add_argument("email", type=email, required=True, location="json")
         parser.add_argument("name", type=StrLen(30), required=True, location="json")
         parser.add_argument("password", type=valid_password, required=True, location="json")
+        parser.add_argument("department", type=str, required=False, location="json")
         args = parser.parse_args()
 
         # setup
         RegisterService.setup(
-            email=args["email"], name=args["name"], password=args["password"], ip_address=extract_remote_ip(request)
+            email=args["email"],
+            name=args["name"],
+            password=args["password"],
+            ip_address=extract_remote_ip(request),
+            department=args.get("department"),
         )
 
         return {"result": "success"}, 201

--- a/api/migrations/versions/2025_06_18_0853-25b14f4b9080_add_department_support.py
+++ b/api/migrations/versions/2025_06_18_0853-25b14f4b9080_add_department_support.py
@@ -1,0 +1,29 @@
+"""add department support
+
+Revision ID: 25b14f4b9080
+Revises: 4474872b0ee6
+Create Date: 2025-06-18 08:53:00
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = '25b14f4b9080'
+down_revision = '4474872b0ee6'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table('tenant_account_joins', schema=None) as batch_op:
+        batch_op.add_column(sa.Column('department', sa.String(length=255), nullable=True))
+    with op.batch_alter_table('apps', schema=None) as batch_op:
+        batch_op.add_column(sa.Column('department', sa.String(length=255), nullable=True))
+
+
+def downgrade():
+    with op.batch_alter_table('apps', schema=None) as batch_op:
+        batch_op.drop_column('department')
+    with op.batch_alter_table('tenant_account_joins', schema=None) as batch_op:
+        batch_op.drop_column('department')

--- a/api/models/account.py
+++ b/api/models/account.py
@@ -105,6 +105,7 @@ class Account(UserMixin, Base):
     def init_on_load(self):
         self.role: Optional[TenantAccountRole] = None
         self._current_tenant: Optional[Tenant] = None
+        self._current_department: Optional[str] = None
 
     @property
     def is_password_set(self):
@@ -120,6 +121,7 @@ class Account(UserMixin, Base):
         if ta:
             self.role = TenantAccountRole(ta.role)
             self._current_tenant = tenant
+            self._current_department = ta.department
             return
         self._current_tenant = None
 
@@ -145,10 +147,15 @@ class Account(UserMixin, Base):
         tenant, join = tenant_account_join
         self.role = join.role
         self._current_tenant = tenant
+        self._current_department = join.department
 
     @property
     def current_role(self):
         return self.role
+
+    @property
+    def current_department(self) -> str | None:
+        return self._current_department
 
     def get_status(self) -> AccountStatus:
         status_str = self.status
@@ -235,6 +242,7 @@ class TenantAccountJoin(Base):
     account_id = db.Column(StringUUID, nullable=False)
     current = db.Column(db.Boolean, nullable=False, server_default=db.text("false"))
     role = db.Column(db.String(16), nullable=False, server_default="normal")
+    department = db.Column(db.String(255), nullable=True)
     invited_by = db.Column(StringUUID, nullable=True)
     created_at = db.Column(db.DateTime, nullable=False, server_default=func.current_timestamp())
     updated_at = db.Column(db.DateTime, nullable=False, server_default=func.current_timestamp())

--- a/api/models/model.py
+++ b/api/models/model.py
@@ -94,6 +94,7 @@ class App(Base):
     is_demo = db.Column(db.Boolean, nullable=False, server_default=db.text("false"))
     is_public = db.Column(db.Boolean, nullable=False, server_default=db.text("false"))
     is_universal = db.Column(db.Boolean, nullable=False, server_default=db.text("false"))
+    department = db.Column(db.String(255), nullable=True)
     tracing = db.Column(db.Text, nullable=True)
     max_active_requests: Mapped[Optional[int]] = mapped_column(nullable=True)
     created_by = db.Column(StringUUID, nullable=True)

--- a/api/services/account_service.py
+++ b/api/services/account_service.py
@@ -247,14 +247,20 @@ class AccountService:
 
     @staticmethod
     def create_account_and_tenant(
-        email: str, name: str, interface_language: str, password: Optional[str] = None
+        email: str,
+        name: str,
+        interface_language: str,
+        password: Optional[str] = None,
+        department: str | None = None,
     ) -> Account:
         """create account"""
         account = AccountService.create_account(
             email=email, name=name, interface_language=interface_language, password=password
         )
 
-        TenantService.create_owner_tenant_if_not_exist(account=account)
+        TenantService.create_owner_tenant_if_not_exist(
+            account=account, department=department
+        )
 
         return account
 
@@ -610,7 +616,10 @@ class TenantService:
 
     @staticmethod
     def create_owner_tenant_if_not_exist(
-        account: Account, name: Optional[str] = None, is_setup: Optional[bool] = False
+        account: Account,
+        name: Optional[str] = None,
+        is_setup: Optional[bool] = False,
+        department: str | None = None,
     ):
         """Check if user have a workspace or not"""
         available_ta = (
@@ -634,14 +643,26 @@ class TenantService:
         if name:
             tenant = TenantService.create_tenant(name=name, is_setup=is_setup)
         else:
-            tenant = TenantService.create_tenant(name=f"{account.name}'s Workspace", is_setup=is_setup)
-        TenantService.create_tenant_member(tenant, account, role="owner")
+            tenant = TenantService.create_tenant(
+                name=f"{account.name}'s Workspace", is_setup=is_setup
+            )
+        TenantService.create_tenant_member(
+            tenant,
+            account,
+            role="owner",
+            department=department,
+        )
         account.current_tenant = tenant
         db.session.commit()
         tenant_was_created.send(tenant)
 
     @staticmethod
-    def create_tenant_member(tenant: Tenant, account: Account, role: str = "normal") -> TenantAccountJoin:
+    def create_tenant_member(
+        tenant: Tenant,
+        account: Account,
+        role: str = "normal",
+        department: str | None = None,
+    ) -> TenantAccountJoin:
         """Create tenant member"""
         if role == TenantAccountRole.OWNER.value:
             if TenantService.has_roles(tenant, [TenantAccountRole.OWNER]):
@@ -651,8 +672,15 @@ class TenantService:
         ta = db.session.query(TenantAccountJoin).filter_by(tenant_id=tenant.id, account_id=account.id).first()
         if ta:
             ta.role = role
+            if department is not None:
+                ta.department = department
         else:
-            ta = TenantAccountJoin(tenant_id=tenant.id, account_id=account.id, role=role)
+            ta = TenantAccountJoin(
+                tenant_id=tenant.id,
+                account_id=account.id,
+                role=role,
+                department=department,
+            )
             db.session.add(ta)
 
         db.session.commit()
@@ -865,7 +893,14 @@ class RegisterService:
         return f"member_invite:token:{token}"
 
     @classmethod
-    def setup(cls, email: str, name: str, password: str, ip_address: str) -> None:
+    def setup(
+        cls,
+        email: str,
+        name: str,
+        password: str,
+        ip_address: str,
+        department: str | None = None,
+    ) -> None:
         """
         Setup dify
 
@@ -887,7 +922,9 @@ class RegisterService:
             account.last_login_ip = ip_address
             account.initialized_at = datetime.now(UTC).replace(tzinfo=None)
 
-            TenantService.create_owner_tenant_if_not_exist(account=account, is_setup=True)
+            TenantService.create_owner_tenant_if_not_exist(
+                account=account, is_setup=True, department=department
+            )
 
             dify_setup = DifySetup(version=dify_config.CURRENT_VERSION)
             db.session.add(dify_setup)
@@ -914,6 +951,7 @@ class RegisterService:
         status: Optional[AccountStatus] = None,
         is_setup: Optional[bool] = False,
         create_workspace_required: Optional[bool] = True,
+        department: str | None = None,
     ) -> Account:
         db.session.begin_nested()
         """Register account"""
@@ -937,7 +975,12 @@ class RegisterService:
                 and FeatureService.get_system_features().license.workspaces.is_available()
             ):
                 tenant = TenantService.create_tenant(f"{account.name}'s Workspace")
-                TenantService.create_tenant_member(tenant, account, role="owner")
+                TenantService.create_tenant_member(
+                    tenant,
+                    account,
+                    role="owner",
+                    department=department,
+                )
                 account.current_tenant = tenant
                 tenant_was_created.send(tenant)
 

--- a/api/services/app_service.py
+++ b/api/services/app_service.py
@@ -5,6 +5,7 @@ from typing import Optional, cast
 
 from flask_login import current_user
 from flask_sqlalchemy.pagination import Pagination
+import sqlalchemy as sa
 
 from configs import dify_config
 from constants.model_template import default_app_templates
@@ -27,7 +28,13 @@ from tasks.remove_app_and_related_data_task import remove_app_and_related_data_t
 
 
 class AppService:
-    def get_paginate_apps(self, user_id: str, tenant_id: str, args: dict) -> Pagination | None:
+    def get_paginate_apps(
+        self,
+        user_id: str,
+        tenant_id: str,
+        args: dict,
+        department: str | None = None,
+    ) -> Pagination | None:
         """
         Get app list with pagination
         :param user_id: user id
@@ -36,6 +43,10 @@ class AppService:
         :return:
         """
         filters = [App.tenant_id == tenant_id, App.is_universal == False]
+        if department:
+            filters.append(
+                sa.or_(App.department.is_(None), App.department == department)
+            )
 
         if args["mode"] == "workflow":
             filters.append(App.mode == AppMode.WORKFLOW.value)
@@ -135,6 +146,7 @@ class AppService:
         app.icon = args["icon"]
         app.icon_background = args["icon_background"]
         app.tenant_id = tenant_id
+        app.department = account.current_department
         app.api_rph = args.get("api_rph", 0)
         app.api_rpm = args.get("api_rpm", 0)
         app.created_by = account.id


### PR DESCRIPTION
## Summary
- allow department assignment to accounts when joining a tenant
- save department info for created apps
- filter app listing by department
- add migration for new columns
- include department in setup and registration flows

## Testing
- `dev/reformat` *(fails: unable to download dependencies)*
- `dev/pytest/pytest_unit_tests.sh` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_685279ef53d8832c9a83de4b237ce02c